### PR TITLE
Feature/display main page data

### DIFF
--- a/src/NavBar/NavBar.js
+++ b/src/NavBar/NavBar.js
@@ -1,5 +1,4 @@
 import './NavBar.css'
-import { NavLink } from 'react-router-dom'
 
 const NavBar = () => {
   return (

--- a/src/PlayerCard/PlayerCard.css
+++ b/src/PlayerCard/PlayerCard.css
@@ -1,0 +1,15 @@
+.player-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  border: 2px solid #128639;
+  border-radius: 5px;
+  padding: 10px;
+  height: 100px;
+  width: 200px;
+  font-size: 18px;
+}
+
+.player-card:hover {
+  cursor: pointer;
+}

--- a/src/PlayerCard/PlayerCard.js
+++ b/src/PlayerCard/PlayerCard.js
@@ -1,0 +1,34 @@
+import './PlayerCard.css'
+import { Component } from 'react'
+import { getPlayerStats } from '../apiCalls'
+
+class PlayerCard extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      firstName: '',
+      lastName: '',
+      position: ''
+    }
+  }
+
+  componentDidMount = async () => {
+    await getPlayerStats(this.props.id)
+    .then(data => this.setState({
+      firstName: data.first_name, 
+      lastName: data.last_name, 
+      position: data.position 
+    }))
+  }
+
+  render() {
+    return(
+      <article className='player-card'>
+        <p>{`${this.state.firstName} ${this.state.lastName}`}</p>
+        <p>{this.state.position}</p>
+      </article>
+    )
+  }
+}
+
+export default PlayerCard

--- a/src/PlayersList/PlayersList.css
+++ b/src/PlayersList/PlayersList.css
@@ -1,6 +1,7 @@
 .players-list {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
+  grid-gap: 20px;
   place-items: center;
-  padding: 20px;
+  padding: 60px;
 }

--- a/src/PlayersList/PlayersList.css
+++ b/src/PlayersList/PlayersList.css
@@ -1,6 +1,6 @@
 .players-list {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-top: 100px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  place-items: center;
+  padding: 20px;
 }

--- a/src/PlayersList/PlayersList.js
+++ b/src/PlayersList/PlayersList.js
@@ -1,19 +1,21 @@
 import './PlayersList.css'
 import { Component } from 'react'
+import PlayerCard from '../PlayerCard/PlayerCard'
 
 class PlayersList extends Component {
   constructor() {
     super()
     this.state = {
-      players: []
+      players: [132, 378]
     }
   }
 
   render() {
     return(
       <section className='players-list'>
-        <p>All Mavs players go here</p>
-        {/* <PlayerCard /> */}
+        {this.state.players.map(player => {
+          return <PlayerCard id={player} key={player}/>
+        })}
       </section>
     )
   }

--- a/src/PlayersList/PlayersList.js
+++ b/src/PlayersList/PlayersList.js
@@ -8,72 +8,72 @@ class PlayersList extends Component {
     this.state = {
       players: [
         {
-          name: 'Luka Doncic',
-          id: 132
-        },
-        {
-          name: 'Kristaps Porzingis',
-          id: 378
+          name: 'Tyler Bey',
+          id: 3547265
         },
         {
           name: 'Jalen Brunson',
           id: 73
         },
         {
-          name: 'Tim Hardaway Jr.',
-          id: 191
-        },
-        {
-          name: 'Josh Richardson',
-          id: 391
-        },
-        {
-          name: 'Maxi Kleber',
-          id: 257
-        },
-        {
-          name: 'Dwight Powell',
-          id: 379
+          name: 'Trey Burke',
+          id: 76
         },
         {
           name: 'Willie Cauley-Stein',
           id: 91
         },
         {
-          name: 'Trey Burke',
-          id: 76
-        },
-        {
-          name: 'James Johnson',
-          id: 242
-        },
-        {
-          name: 'Josh Green',
-          id: 3547258
+          name: 'Luka Doncic',
+          id: 132
         },
         {
           name: 'Dorian Finney-Smith',
           id: 158
         },
         {
-          name: 'Tyrell Terry',
-          id: 3547255
+          name: 'Josh Green',
+          id: 3547258
         },
         {
-          name: 'Tyler Bey',
-          id: 3547265
-        },
-        {
-          name: 'Wes Iwundu',
-          id: 230
+          name: 'Tim Hardaway Jr.',
+          id: 191
         },
         {
           name: 'Nate Hinton',
           id: 3547281
         },
         {
+          name: 'Wes Iwundu',
+          id: 230
+        },
+        {
+          name: 'James Johnson',
+          id: 242
+        },
+        {
+          name: 'Maxi Kleber',
+          id: 257
+        },
+        {
           name: 'Boban Marjanovic',
           id: 296
+        },
+        {
+          name: 'Kristaps Porzingis',
+          id: 378
+        },
+        {
+          name: 'Dwight Powell',
+          id: 379
+        },
+        {
+          name: 'Josh Richardson',
+          id: 391
+        },
+        {
+          name: 'Tyrell Terry',
+          id: 3547255
         }
       ]
     }

--- a/src/PlayersList/PlayersList.js
+++ b/src/PlayersList/PlayersList.js
@@ -6,7 +6,76 @@ class PlayersList extends Component {
   constructor() {
     super()
     this.state = {
-      players: [132, 378]
+      players: [
+        {
+          name: 'Luka Doncic',
+          id: 132
+        },
+        {
+          name: 'Kristaps Porzingis',
+          id: 378
+        },
+        {
+          name: 'Jalen Brunson',
+          id: 73
+        },
+        {
+          name: 'Tim Hardaway Jr.',
+          id: 191
+        },
+        {
+          name: 'Josh Richardson',
+          id: 391
+        },
+        {
+          name: 'Maxi Kleber',
+          id: 257
+        },
+        {
+          name: 'Dwight Powell',
+          id: 379
+        },
+        {
+          name: 'Willie Cauley-Stein',
+          id: 91
+        },
+        {
+          name: 'Trey Burke',
+          id: 76
+        },
+        {
+          name: 'James Johnson',
+          id: 242
+        },
+        {
+          name: 'Josh Green',
+          id: 3547258
+        },
+        {
+          name: 'Dorian Finney-Smith',
+          id: 158
+        },
+        {
+          name: 'Tyrell Terry',
+          id: 3547255
+        },
+        {
+          name: 'Tyler Bey',
+          id: 3547265
+        },
+        {
+          name: 'Wes Iwundu',
+          id: 230
+        },
+        {
+          name: 'Nate Hinton',
+          id: 3547281
+        },
+        {
+          name: 'Boban Marjanovic',
+          id: 296
+        }
+      ]
     }
   }
 
@@ -14,7 +83,7 @@ class PlayersList extends Component {
     return(
       <section className='players-list'>
         {this.state.players.map(player => {
-          return <PlayerCard id={player} key={player}/>
+          return <PlayerCard id={player.id} key={player.id}/>
         })}
       </section>
     )

--- a/src/TeamStats/TeamStats.css
+++ b/src/TeamStats/TeamStats.css
@@ -1,6 +1,13 @@
 .team-stats {
   display: flex;
   flex-direction: column;
+  justify-content: space-around;
   align-items: center;
-  margin-top: 100px;
+  color: #002958;
+  font-size: 18px;
+}
+
+.team-name {
+  font-size: 30px;
+  margin-bottom: 10px;
 }

--- a/src/TeamStats/TeamStats.js
+++ b/src/TeamStats/TeamStats.js
@@ -24,9 +24,9 @@ class TeamStats extends Component {
   render() {
     return(
       <section className='team-stats'>
-        <p>Team Name: {this.state.fullName}</p>
-        <p>Conference: {this.state.conference}</p>
-        <p>Division: {this.state.division}</p>
+        <p className='team-name'>{this.state.fullName}</p>
+        <p>{this.state.conference}ern Conference</p>
+        <p>{this.state.division} Division</p>
       </section>
     )
   }

--- a/src/TeamStats/TeamStats.js
+++ b/src/TeamStats/TeamStats.js
@@ -1,11 +1,35 @@
 import './TeamStats.css'
+import { Component } from 'react'
+import { getTeamStats } from '../apiCalls'
 
-const TeamStats = () => {
-  return(
-    <section className='team-stats'>
-      <p>Mavs team stats go here</p>
-    </section>
-  )
+class TeamStats extends Component {
+  constructor() {
+    super()
+    this.state = {
+      fullName: '',
+      conference: '',
+      division: '',
+    }
+  }
+
+  componentDidMount = async () => {
+    await getTeamStats(7)
+    .then(data => this.setState({
+      fullName: data.full_name, 
+      conference: data.conference, 
+      division: data.division 
+    }))
+  }
+
+  render() {
+    return(
+      <section className='team-stats'>
+        <p>Team Name: {this.state.fullName}</p>
+        <p>Conference: {this.state.conference}</p>
+        <p>Division: {this.state.division}</p>
+      </section>
+    )
+  }
 }
 
 export default TeamStats

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,0 +1,11 @@
+const getTeamStats = (id) => {
+  return fetch(`https://www.balldontlie.io/api/v1/teams/${id}`)
+  .then(response => response.json())
+}
+
+const getPlayerStats = (id) => {
+  return fetch(`https://balldontlie.io/api/v1/players/${id}`)
+  .then(response => response.json())
+}
+
+export { getTeamStats, getPlayerStats }

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -4,7 +4,7 @@ const getTeamStats = (id) => {
 }
 
 const getPlayerStats = (id) => {
-  return fetch(`https://balldontlie.io/api/v1/players/${id}`)
+  return fetch(`https://www.balldontlie.io/api/v1/players/${id}`)
   .then(response => response.json())
 }
 


### PR DESCRIPTION
## What’s this PR do?
- Makes API calls to fetch player and team data
- Displays data on the main page

## Where should the reviewer start?
- At the top of each corresponding file

## How should this be manually tested?
- By running `npm start` in the terminal to see the main page data

## Any background context you want to provide?
- There is still no functionality on the page, just a display of data